### PR TITLE
fix: disable unfinished benchmark features in interactive UX

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -24,6 +24,7 @@ interface MenuItem {
 }
 
 const allMenuItems: MenuItem[] = [
+  /**
   {
     key: "benchmarks",
     label: "Benchmarks",
@@ -31,6 +32,7 @@ const allMenuItems: MenuItem[] = [
     icon: "▷",
     color: colors.success,
   },
+  */
   {
     key: "devboxes",
     label: "Devboxes",
@@ -188,8 +190,10 @@ export const MainMenu = ({ onSelect }: MainMenuProps) => {
       selectByKey("snapshots");
     } else if (input === "o") {
       selectByKey("objects");
+      /**
     } else if (input === "e") {
       selectByKey("benchmarks");
+    */
     } else if (input === "n") {
       selectByKey("settings");
     } else if (input >= "1" && input <= "9") {


### PR DESCRIPTION
The interactive benchmark features are not finished yet.  Removing them from the main menu until they are ready.