### PR TITLE
fix(cli): account for pending scenarios in rli display

### DIFF
--- a/src/commands/benchmark-job/watch.ts
+++ b/src/commands/benchmark-job/watch.ts
@@ -147,6 +147,12 @@ function formatRunProgressLine(progress: RunProgress): string {
     parts.push(`${progress.scoring} scoring`);
   }
 
+  // Pending = scenarios not yet started (expected minus actually started)
+  const notStarted = total - progress.started;
+  if (notStarted > 0) {
+    parts.push(`${notStarted} pending`);
+  }
+
   if (progress.avgScore !== null) {
     parts.push(`score: ${(progress.avgScore * 100).toFixed(0)}%`);
   }


### PR DESCRIPTION
Scenarios in pending/not-yet-started states were not reflected in any counter, making the displayed numbers sum to less than the total. Added a computed "pending" count to fill the gap.
