### PR TITLE
perf: fetch total count in the background, not foreground

### DIFF
--- a/src/commands/blueprint/list.tsx
+++ b/src/commands/blueprint/list.tsx
@@ -364,9 +364,13 @@ const ListBlueprintsUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + blueprints.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + blueprints.length, totalCount)
+      : startIndex + blueprints.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -908,14 +912,18 @@ const ListBlueprintsUI = ({
       {/* Statistics Bar */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -933,11 +941,11 @@ const ListBlueprintsUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/blueprint/list.tsx
+++ b/src/commands/blueprint/list.tsx
@@ -940,13 +940,17 @@ const ListBlueprintsUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/devbox/list.tsx
+++ b/src/commands/devbox/list.tsx
@@ -425,9 +425,13 @@ const ListDevboxesUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + devboxes.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + devboxes.length, totalCount)
+      : startIndex + devboxes.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -732,14 +736,18 @@ const ListDevboxesUI = ({
       {/* Statistics Bar - hide when popup is shown */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -757,11 +765,11 @@ const ListDevboxesUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/devbox/list.tsx
+++ b/src/commands/devbox/list.tsx
@@ -764,13 +764,21 @@ const ListDevboxesUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {devboxes.length > 0 && (
+            <>
+              {endIndex > startIndex && (
+                <>
+                  <Text color={colors.textDim} dimColor>
+                    {totalCount > 0 ? " • " : ""}
+                  </Text>
+                  <Text color={colors.textDim} dimColor>
+                    Showing {showingRange}
+                    {totalCount > 0 ? ` of ${totalCount}` : ""}
+                  </Text>
+                </>
+              )}
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/gateway-config/list.tsx
+++ b/src/commands/gateway-config/list.tsx
@@ -711,13 +711,17 @@ const ListGatewayConfigsUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/gateway-config/list.tsx
+++ b/src/commands/gateway-config/list.tsx
@@ -312,9 +312,13 @@ const ListGatewayConfigsUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + configs.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + configs.length, totalCount)
+      : startIndex + configs.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -679,14 +683,18 @@ const ListGatewayConfigsUI = ({
       {/* Statistics Bar - hide when popup is shown */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -704,11 +712,11 @@ const ListGatewayConfigsUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/mcp-config/list.tsx
+++ b/src/commands/mcp-config/list.tsx
@@ -636,13 +636,17 @@ const ListMcpConfigsUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/mcp-config/list.tsx
+++ b/src/commands/mcp-config/list.tsx
@@ -274,9 +274,13 @@ const ListMcpConfigsUI = ({
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + configs.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + configs.length, totalCount)
+      : startIndex + configs.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -604,14 +608,18 @@ const ListMcpConfigsUI = ({
 
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -629,11 +637,11 @@ const ListMcpConfigsUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/network-policy/list.tsx
+++ b/src/commands/network-policy/list.tsx
@@ -740,13 +740,17 @@ const ListNetworkPoliciesUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/network-policy/list.tsx
+++ b/src/commands/network-policy/list.tsx
@@ -349,9 +349,13 @@ const ListNetworkPoliciesUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + policies.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + policies.length, totalCount)
+      : startIndex + policies.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -708,14 +712,18 @@ const ListNetworkPoliciesUI = ({
       {/* Statistics Bar - hide when popup is shown */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -733,11 +741,11 @@ const ListNetworkPoliciesUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/object/list.tsx
+++ b/src/commands/object/list.tsx
@@ -351,9 +351,13 @@ const ListObjectsUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + objects.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + objects.length, totalCount)
+      : startIndex + objects.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -749,14 +753,18 @@ const ListObjectsUI = ({
       {/* Statistics Bar - hide when popup is shown */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -774,11 +782,11 @@ const ListObjectsUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/object/list.tsx
+++ b/src/commands/object/list.tsx
@@ -781,13 +781,17 @@ const ListObjectsUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/secret/list.tsx
+++ b/src/commands/secret/list.tsx
@@ -582,13 +582,17 @@ const ListSecretsUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/secret/list.tsx
+++ b/src/commands/secret/list.tsx
@@ -241,9 +241,13 @@ const ListSecretsUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + secrets.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + secrets.length, totalCount)
+      : startIndex + secrets.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -550,14 +554,18 @@ const ListSecretsUI = ({
       {/* Statistics Bar - hide when popup is shown */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -575,11 +583,11 @@ const ListSecretsUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/commands/snapshot/list.tsx
+++ b/src/commands/snapshot/list.tsx
@@ -653,13 +653,17 @@ const ListSnapshotsUI = ({
               )}
             </>
           )}
-          <Text color={colors.textDim} dimColor>
-            {totalCount > 0 ? " • " : ""}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            Showing {showingRange}
-            {totalCount > 0 ? ` of ${totalCount}` : ""}
-          </Text>
+          {endIndex > startIndex && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {totalCount > 0 ? " • " : ""}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                Showing {showingRange}
+                {totalCount > 0 ? ` of ${totalCount}` : ""}
+              </Text>
+            </>
+          )}
           {search.submittedSearchQuery && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/commands/snapshot/list.tsx
+++ b/src/commands/snapshot/list.tsx
@@ -276,9 +276,13 @@ const ListSnapshotsUI = ({
   // Calculate pagination info for display
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = currentPage * PAGE_SIZE;
-  const endIndex = Math.min(startIndex + snapshots.length, totalCount);
-  const showingRange =
-    endIndex === startIndex + 1
+  const endIndex =
+    totalCount > 0
+      ? Math.min(startIndex + snapshots.length, totalCount)
+      : startIndex + snapshots.length;
+  const showingRange = navigating
+    ? `${startIndex + 1}+`
+    : endIndex === startIndex + 1
       ? `${startIndex + 1}`
       : `${startIndex + 1}-${endIndex}`;
 
@@ -621,14 +625,18 @@ const ListSnapshotsUI = ({
       {/* Statistics Bar - hide when popup is shown */}
       {!showPopup && (
         <Box marginTop={1} paddingX={1}>
-          <Text color={colors.primary} bold>
-            {figures.hamburger} {totalCount}
-          </Text>
-          <Text color={colors.textDim} dimColor>
-            {" "}
-            total
-          </Text>
-          {totalPages > 1 && (
+          {totalCount > 0 && (
+            <>
+              <Text color={colors.primary} bold>
+                {figures.hamburger} {totalCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                total
+              </Text>
+            </>
+          )}
+          {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>
                 {" "}
@@ -646,11 +654,11 @@ const ListSnapshotsUI = ({
             </>
           )}
           <Text color={colors.textDim} dimColor>
-            {" "}
-            •{" "}
+            {totalCount > 0 ? " • " : ""}
           </Text>
           <Text color={colors.textDim} dimColor>
-            Showing {showingRange} of {totalCount}
+            Showing {showingRange}
+            {totalCount > 0 ? ` of ${totalCount}` : ""}
           </Text>
           {search.submittedSearchQuery && (
             <>

--- a/src/hooks/useCursorPagination.ts
+++ b/src/hooks/useCursorPagination.ts
@@ -108,6 +108,9 @@ export function useCursorPagination<T>(
   // Track if we have a cached total count from the API (to avoid re-requesting)
   const hasCachedTotalCountRef = React.useRef(false);
 
+  // Abort controller for cancelling in-flight count requests
+  const countAbortRef = React.useRef<AbortController | null>(null);
+
   // Cursor history: cursorHistory[N] = last item ID of page N
   // Used to determine startingAt for page N+1
   const cursorHistoryRef = React.useRef<(string | undefined)[]>([]);
@@ -176,13 +179,11 @@ export function useCursorPagination<T>(
         const startingAt =
           page > 0 ? cursorHistoryRef.current[page - 1] : undefined;
 
-        // Only request total_count on first fetch or when we don't have it cached
-        const includeTotalCount = !hasCachedTotalCountRef.current;
-
+        // Never request total_count in the main data fetch — it's fetched asynchronously
         const result = await fetchPageRef.current({
           limit: pageSizeRef.current,
           startingAt,
-          includeTotalCount,
+          includeTotalCount: false,
         });
 
         if (!isMountedRef.current) return;
@@ -201,18 +202,12 @@ export function useCursorPagination<T>(
         // Update pagination state
         setHasMore(result.hasMore);
 
-        // Use API's totalCount if available (only on first fetch), otherwise keep existing
-        if (
-          result.totalCount !== undefined &&
-          result.totalCount > 0 &&
-          !hasCachedTotalCountRef.current
-        ) {
-          setTotalCount(result.totalCount);
+        // If has_more is false on any page, we know the exact total count.
+        // Cancel the background count request if still pending.
+        if (!result.hasMore && !hasCachedTotalCountRef.current) {
+          countAbortRef.current?.abort();
+          setTotalCount(page * pageSizeRef.current + result.items.length);
           hasCachedTotalCountRef.current = true;
-        } else if (!hasCachedTotalCountRef.current) {
-          // Fallback: compute from items seen so far (for APIs that don't support total_count)
-          const computed = page * pageSizeRef.current + result.items.length;
-          setTotalCount((prev) => Math.max(computed, prev));
         }
       } catch (err) {
         if (!isMountedRef.current) return;
@@ -237,9 +232,34 @@ export function useCursorPagination<T>(
     setCurrentPage(0);
     setItems([]);
     setHasMore(false);
-    setTotalCount(0);
-    // Fetch page 0
+    // Don't reset totalCount to 0 — keep old value visible while new count loads
+    // Fire both data and count requests immediately in parallel.
+    // If the data request returns first with hasMore=false, cancel the count request.
+    countAbortRef.current?.abort();
+    const countAbort = new AbortController();
+    countAbortRef.current = countAbort;
+    let cancelled = false;
+
+    // Data fetch
     fetchPageData(0, true);
+
+    // Background count fetch — fires immediately alongside data
+    fetchPageRef
+      .current({ limit: 0, startingAt: undefined, includeTotalCount: true })
+      .then((result) => {
+        if (cancelled || countAbort.signal.aborted || !isMountedRef.current)
+          return;
+        if (result.totalCount !== undefined) {
+          setTotalCount(result.totalCount);
+          hasCachedTotalCountRef.current = true;
+        }
+      })
+      .catch(() => {}); // count failure is non-critical
+
+    return () => {
+      cancelled = true;
+      countAbort.abort();
+    };
   }, [depsKey, fetchPageData]);
 
   // Polling effect - STOP polling when there's an error to avoid flickering


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

### if total_count isn't known yet

The `of {total_count}` is omitted.

When fetching current page, if it's still pending, it will show `{beginning number}+` since it technically doesn't know the actual ending number since it could be the last page and have less then max #. Once current page is done fetching, it will then show the _accurate_ ending #.

### if total_count becomes known

We can finally append ` of {total_count}`

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test updates

## Related Issues

<!-- Link to related issues using #issue-number -->
Closes #

## Changes Made

<!-- Describe the changes in detail -->

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested locally
- [ ] I have added/updated tests
- [x] All existing tests pass

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
