### PR TITLE
fix: widen VERSION column in agent list to prevent truncation

### DIFF
--- a/src/commands/agent/list.ts
+++ b/src/commands/agent/list.ts
@@ -17,7 +17,7 @@ interface ListOptions {
 }
 
 // Column widths (NAME is dynamic, takes remaining space)
-const COL_VERSION = 14;
+const COL_VERSION = 18;
 const COL_VISIBILITY = 10;
 const COL_ID = 30;
 const COL_CREATED = 10;


### PR DESCRIPTION
## Summary
- Increased `COL_VERSION` from 14 to 18 characters in `src/commands/agent/list.ts`
- Prevents version strings from being truncated in `rli agent list` output

## Test plan
- [ ] Run `rli agent list` and verify VERSION column displays full version strings without truncation
- [ ] Verify table layout remains properly aligned at various terminal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)