### PR TITLE
fix: clean stdout for --config-only when appending SSH config

### DIFF
--- a/src/commands/devbox/ssh.ts
+++ b/src/commands/devbox/ssh.ts
@@ -4,6 +4,7 @@
 
 import { spawn } from "child_process";
 import { getClient } from "../../utils/client.js";
+import { cliStatus } from "../../utils/cliStatus.js";
 import { output, outputError } from "../../utils/output.js";
 import { processUtils } from "../../utils/processUtils.js";
 import {
@@ -36,11 +37,14 @@ export async function sshDevbox(devboxId: string, options: SSHOptions = {}) {
 
     // Wait for devbox to be ready unless --no-wait is specified
     if (!options.noWait) {
-      console.error(`Waiting for devbox ${devboxId} to be ready...`);
+      if (!options.configOnly) {
+        cliStatus(`Waiting for devbox ${devboxId} to be ready...`);
+      }
       const isReady = await waitForReady(
         devboxId,
         options.timeout || 180,
         options.pollInterval || 3,
+        { quiet: options.configOnly },
       );
       if (!isReady) {
         outputError(`Devbox ${devboxId} is not ready. Please try again later.`);

--- a/src/commands/devbox/ssh.ts
+++ b/src/commands/devbox/ssh.ts
@@ -64,7 +64,12 @@ export async function sshDevbox(devboxId: string, options: SSHOptions = {}) {
         sshInfo!.keyfilePath,
         sshInfo!.url,
       );
-      output({ config }, { format: options.output, defaultFormat: "text" });
+      const format = options.output ?? "text";
+      if (format === "text") {
+        console.log(config);
+      } else {
+        output({ config }, { format, defaultFormat: "text" });
+      }
       return;
     }
 

--- a/src/utils/cliStatus.ts
+++ b/src/utils/cliStatus.ts
@@ -1,0 +1,10 @@
+/**
+ * Status / progress lines for the CLI. Uses stderr so stdout stays free for
+ * data users redirect or pipe (e.g. SSH config snippets, JSON).
+ *
+ * Prefer this over console.error for non-failure messages—console.error reads
+ * like a runtime error to humans and tools.
+ */
+export function cliStatus(message: string): void {
+  process.stderr.write(`${message}\n`);
+}

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -4,6 +4,7 @@ import { writeFile, mkdir, chmod } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
 import { getClient } from "./client.js";
+import { cliStatus } from "./cliStatus.js";
 import { processUtils } from "./processUtils.js";
 
 const execAsync = promisify(exec);
@@ -71,6 +72,11 @@ export async function getSSHKey(devboxId: string): Promise<SSHKeyInfo | null> {
   }
 }
 
+export interface WaitForReadyOptions {
+  /** If true, omit periodic poll lines (e.g. when stdout must stay machine-clean). */
+  quiet?: boolean;
+}
+
 /**
  * Wait for a devbox to be ready
  */
@@ -78,7 +84,9 @@ export async function waitForReady(
   devboxId: string,
   timeoutSeconds: number = 180,
   pollIntervalSeconds: number = 3,
+  waitOptions?: WaitForReadyOptions,
 ): Promise<boolean> {
+  const quiet = waitOptions?.quiet ?? false;
   const startTime = Date.now();
   const client = getClient();
 
@@ -89,25 +97,26 @@ export async function waitForReady(
       const remaining = timeoutSeconds - elapsed;
 
       if (devbox.status === "running") {
-        console.error(`Devbox ${devboxId} is ready!`);
         return true;
       } else if (devbox.status === "failure") {
-        console.error(
+        cliStatus(
           `Devbox ${devboxId} failed to start (status: ${devbox.status})`,
         );
         return false;
       } else if (["shutdown", "suspended"].includes(devbox.status)) {
-        console.error(
+        cliStatus(
           `Devbox ${devboxId} is not running (status: ${devbox.status})`,
         );
         return false;
       } else {
-        console.error(
-          `Devbox ${devboxId} is still ${devbox.status}... (elapsed: ${elapsed.toFixed(0)}s, remaining: ${remaining.toFixed(0)}s)`,
-        );
+        if (!quiet) {
+          cliStatus(
+            `Devbox ${devboxId} is still ${devbox.status}... (elapsed: ${elapsed.toFixed(0)}s, remaining: ${remaining.toFixed(0)}s)`,
+          );
+        }
 
         if (elapsed >= timeoutSeconds) {
-          console.error(
+          cliStatus(
             `Timeout waiting for devbox ${devboxId} to be ready after ${timeoutSeconds} seconds`,
           );
           return false;
@@ -120,15 +129,17 @@ export async function waitForReady(
     } catch (error) {
       const elapsed = (Date.now() - startTime) / 1000;
       if (elapsed >= timeoutSeconds) {
-        console.error(
+        cliStatus(
           `Timeout waiting for devbox ${devboxId} to be ready after ${timeoutSeconds} seconds (error: ${error})`,
         );
         return false;
       }
 
-      console.error(
-        `Error checking devbox status: ${error}, retrying in ${pollIntervalSeconds} seconds...`,
-      );
+      if (!quiet) {
+        cliStatus(
+          `Error checking devbox status: ${error}, retrying in ${pollIntervalSeconds} seconds...`,
+        );
+      }
       await new Promise((resolve) =>
         setTimeout(resolve, pollIntervalSeconds * 1000),
       );

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -89,25 +89,25 @@ export async function waitForReady(
       const remaining = timeoutSeconds - elapsed;
 
       if (devbox.status === "running") {
-        console.log(`Devbox ${devboxId} is ready!`);
+        console.error(`Devbox ${devboxId} is ready!`);
         return true;
       } else if (devbox.status === "failure") {
-        console.log(
+        console.error(
           `Devbox ${devboxId} failed to start (status: ${devbox.status})`,
         );
         return false;
       } else if (["shutdown", "suspended"].includes(devbox.status)) {
-        console.log(
+        console.error(
           `Devbox ${devboxId} is not running (status: ${devbox.status})`,
         );
         return false;
       } else {
-        console.log(
+        console.error(
           `Devbox ${devboxId} is still ${devbox.status}... (elapsed: ${elapsed.toFixed(0)}s, remaining: ${remaining.toFixed(0)}s)`,
         );
 
         if (elapsed >= timeoutSeconds) {
-          console.log(
+          console.error(
             `Timeout waiting for devbox ${devboxId} to be ready after ${timeoutSeconds} seconds`,
           );
           return false;
@@ -120,13 +120,13 @@ export async function waitForReady(
     } catch (error) {
       const elapsed = (Date.now() - startTime) / 1000;
       if (elapsed >= timeoutSeconds) {
-        console.log(
+        console.error(
           `Timeout waiting for devbox ${devboxId} to be ready after ${timeoutSeconds} seconds (error: ${error})`,
         );
         return false;
       }
 
-      console.log(
+      console.error(
         `Error checking devbox status: ${error}, retrying in ${pollIntervalSeconds} seconds...`,
       );
       await new Promise((resolve) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`rli devbox ssh <id> --config-only >> ~/.ssh/config` was polluting the config file because:

1. **Readiness messages used stdout** — `waitForReady` logged via `console.log`, so lines like `Devbox … is ready!` were captured by the redirect.
2. **Text output wrapped the block** — `output({ config }, …)` rendered as `config: …` instead of a raw `Host` stanza.

## Changes

- Route all `waitForReady` status lines to **stderr** (`console.error`).
- For `--config-only` with default **text** output, print the generated SSH config with **`console.log(config)`** only (no `config:` prefix). JSON/YAML (`-o json|yaml`) still use the structured `output()` helper.

## Testing

- `pnpm run build`
- `pnpm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://runloophq.slack.com/archives/C0AH4DJ5HB8/p1775174248460909?thread_ts=1775174248.460909&cid=C0AH4DJ5HB8)

<div><a href="https://cursor.com/agents/bc-c0ca94a0-3e42-5fb6-9e97-56251263a648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0ca94a0-3e42-5fb6-9e97-56251263a648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

