### PR TITLE
chore: add dependency age check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,29 @@ jobs:
           path: coverage/
           retention-days: 7
 
+  dependency-check:
+    runs-on: ubuntu-slim
+    if: (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')) || (github.event_name == 'pull_request_target' && startsWith(github.event.pull_request.head.ref, 'release-please--'))
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Fetch base ref
+        run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+
+      - name: Check dependency age (supply-chain gate)
+        uses: runloopai/dependency-age-check-action@main
+        with:
+          ecosystems: npm
+          min-age-days: "14"
+          base-ref: origin/${{ github.event.pull_request.base.ref }}
+
   ready-to-merge:
     runs-on: ubuntu-slim
-    needs: [format, lint, build, test]
+    needs: [format, lint, build, test, dependency-check]
     # Run from pull_request for non-release-please branches, or pull_request_target for release-please branches only
     if: always() && ((github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')) || (github.event_name == 'pull_request_target' && startsWith(github.event.pull_request.head.ref, 'release-please--')) || github.event_name == 'workflow_dispatch')
     steps:
@@ -140,7 +160,8 @@ jobs:
           if [[ "${{ needs.format.result }}" != "success" ]] || \
              [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
-             [[ "${{ needs.test.result }}" != "success" ]]; then
+             [[ "${{ needs.test.result }}" != "success" ]] || \
+             [[ "${{ needs.dependency-check.result }}" != "success" && "${{ needs.dependency-check.result }}" != "skipped" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
   dependency-check:
     runs-on: ubuntu-slim
-    if: (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')) || (github.event_name == 'pull_request_target' && startsWith(github.event.pull_request.head.ref, 'release-please--'))
+    if: github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -151,6 +151,7 @@ jobs:
 
   ready-to-merge:
     runs-on: ubuntu-slim
+    permissions: {}
     needs: [format, lint, build, test, dependency-check]
     # Run from pull_request for non-release-please branches, or pull_request_target for release-please branches only
     if: always() && ((github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')) || (github.event_name == 'pull_request_target' && startsWith(github.event.pull_request.head.ref, 'release-please--')) || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
## Summary
- Adds `dependency-check` job to CI workflow using `runloopai/dependency-age-check-action@main`
- Checks that newly added npm packages in `pnpm-lock.yaml` were published at least 14 days ago
- Added to `ready-to-merge` gate (allows `skipped` for `workflow_dispatch` runs)

## Test plan
- [ ] Open a PR with a lockfile change and verify the check runs
- [ ] Verify `workflow_dispatch` still passes (dependency-check is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)