### PR TITLE
feat: gray out conflicting agents in picker

### DIFF
--- a/src/components/DevboxCreatePage.tsx
+++ b/src/components/DevboxCreatePage.tsx
@@ -2506,7 +2506,18 @@ export const DevboxCreatePage = ({
           if (formData.agentMounts.some((m) => m.agent_id === agent.id)) {
             return "Already selected";
           }
-          return null;
+          const candidateMount: AgentMountInfo = {
+            agent_id: agent.id,
+            agent_name: agent.name,
+            source_type: agent.source?.type,
+            package_name:
+              agent.source?.type === "npm"
+                ? agent.source.npm?.package_name
+                : agent.source?.type === "pip"
+                  ? agent.source.pip?.package_name
+                  : undefined,
+          };
+          return wouldAgentConflict(candidateMount, formData.agentMounts);
         }}
       />
     );


### PR DESCRIPTION
## Summary
- Gray out already-selected agents in the agent picker (not just hide them)
- Extend to gray out agents that would conflict via `wouldAgentConflict()` (duplicate name, same npm/pip package)
- Added `isItemDisabled` to `ResourcePicker` and `isRowDisabled` to `Table` for reusable disabled-row support
- Navigation automatically skips disabled rows; selection is prevented on disabled items

## Changes
- `ResourcePicker`: new `isItemDisabled` config option, `findNextEnabled()` navigation helper
- `Table`: new `isRowDisabled` prop, disabled rows get dimmed styling with no pointer/inverse
- `DevboxCreatePage`: uses `wouldAgentConflict()` to determine which agents to gray out
- `mountValidation.ts`: added `wouldAgentConflict()` utility + tests

## Test plan
- [ ] Select an agent, re-open picker — selected agent is grayed out and unskippable
- [ ] Select a pip agent, re-open picker — other versions of same pip package are grayed out
- [ ] Select an npm agent — same npm package agents are grayed out
- [ ] Arrow keys skip over grayed-out rows
- [ ] Enter/Space on grayed-out row does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)