### PR TITLE
feat: create devbox from agent detail screen

### DIFF
--- a/src/components/DevboxCreatePage.tsx
+++ b/src/components/DevboxCreatePage.tsx
@@ -39,6 +39,7 @@ import { SecretCreatePage } from "./SecretCreatePage.js";
 import { GatewayConfigCreatePage } from "./GatewayConfigCreatePage.js";
 import { McpConfigCreatePage } from "./McpConfigCreatePage.js";
 import {
+  getAgent,
   listAgents,
   listPublicAgents,
   type Agent,
@@ -60,6 +61,7 @@ interface DevboxCreatePageProps {
   onCreate?: (devbox: DevboxView) => void;
   initialBlueprintId?: string;
   initialSnapshotId?: string;
+  initialAgentId?: string;
 }
 
 type FormField =
@@ -254,6 +256,7 @@ export const DevboxCreatePage = ({
   onCreate,
   initialBlueprintId,
   initialSnapshotId,
+  initialAgentId,
 }: DevboxCreatePageProps) => {
   const [currentField, setCurrentField] = React.useState<FormField>("create");
   const [formData, setFormData] = React.useState<FormData>({
@@ -372,6 +375,46 @@ export const DevboxCreatePage = ({
     React.useState(0);
   const [editingObjectMountPath, setEditingObjectMountPath] =
     React.useState(false);
+
+  // Load initial agent if provided (e.g., from "Create Devbox" on agent detail)
+  React.useEffect(() => {
+    if (!initialAgentId) return;
+    let cancelled = false;
+    getAgent(initialAgentId).then((agent) => {
+      if (cancelled) return;
+      const source = (agent as unknown as Record<string, unknown>).source as
+        | {
+            type?: string;
+            npm?: { package_name?: string };
+            pip?: { package_name?: string };
+          }
+        | undefined;
+      setFormData((prev) => ({
+        ...prev,
+        agentMounts: [
+          ...prev.agentMounts,
+          {
+            agent_id: agent.id,
+            agent_name: agent.name,
+            agent_path: "",
+            source_type: source?.type,
+            version: (agent as unknown as Record<string, unknown>).version as
+              | string
+              | undefined,
+            package_name:
+              source?.type === "npm"
+                ? source.npm?.package_name
+                : source?.type === "pip"
+                  ? source.pip?.package_name
+                  : undefined,
+          },
+        ],
+      }));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [initialAgentId]);
 
   const baseFields: Array<{
     key: FormField;

--- a/src/components/DevboxCreatePage.tsx
+++ b/src/components/DevboxCreatePage.tsx
@@ -380,37 +380,33 @@ export const DevboxCreatePage = ({
   React.useEffect(() => {
     if (!initialAgentId) return;
     let cancelled = false;
-    getAgent(initialAgentId).then((agent) => {
-      if (cancelled) return;
-      const source = (agent as unknown as Record<string, unknown>).source as
-        | {
-            type?: string;
-            npm?: { package_name?: string };
-            pip?: { package_name?: string };
-          }
-        | undefined;
-      setFormData((prev) => ({
-        ...prev,
-        agentMounts: [
-          ...prev.agentMounts,
-          {
-            agent_id: agent.id,
-            agent_name: agent.name,
-            agent_path: "",
-            source_type: source?.type,
-            version: (agent as unknown as Record<string, unknown>).version as
-              | string
-              | undefined,
-            package_name:
-              source?.type === "npm"
-                ? source.npm?.package_name
-                : source?.type === "pip"
-                  ? source.pip?.package_name
-                  : undefined,
-          },
-        ],
-      }));
-    });
+    getAgent(initialAgentId)
+      .then((agent) => {
+        if (cancelled) return;
+        const source = agent.source;
+        setFormData((prev) => ({
+          ...prev,
+          agentMounts: [
+            ...prev.agentMounts,
+            {
+              agent_id: agent.id,
+              agent_name: agent.name,
+              agent_path: "",
+              source_type: source?.type,
+              version: agent.version,
+              package_name:
+                source?.type === "npm"
+                  ? source.npm?.package_name
+                  : source?.type === "pip"
+                    ? source.pip?.package_name
+                    : undefined,
+            },
+          ],
+        }));
+      })
+      .catch(() => {
+        /* silently ignore — agent may not be accessible */
+      });
     return () => {
       cancelled = true;
     };

--- a/src/components/DevboxCreatePage.tsx
+++ b/src/components/DevboxCreatePage.tsx
@@ -287,6 +287,9 @@ export const DevboxCreatePage = ({
   const [creating, setCreating] = React.useState(false);
   const [result, setResult] = React.useState<DevboxView | null>(null);
   const [error, setError] = React.useState<Error | null>(null);
+  const [loadAgentError, setLoadAgentError] = React.useState<string | null>(
+    null,
+  );
 
   // Source picker states (toggle between blueprint/snapshot)
   const [sourceTypeToggle, setSourceTypeToggle] = React.useState<
@@ -412,8 +415,11 @@ export const DevboxCreatePage = ({
           };
         });
       })
-      .catch(() => {
-        /* silently ignore — agent may not be accessible */
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadAgentError(
+          `Could not load agent ${initialAgentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       });
     return () => {
       cancelled = true;
@@ -2540,6 +2546,12 @@ export const DevboxCreatePage = ({
       <Breadcrumb
         items={[{ label: "Devboxes" }, { label: "Create", active: true }]}
       />
+
+      {loadAgentError && (
+        <Box paddingX={2} marginBottom={1}>
+          <Text color={colors.warning}>{figures.warning} {loadAgentError}</Text>
+        </Box>
+      )}
 
       <Box flexDirection="column" marginBottom={1}>
         {fields.map((field) => {

--- a/src/components/DevboxCreatePage.tsx
+++ b/src/components/DevboxCreatePage.tsx
@@ -383,26 +383,34 @@ export const DevboxCreatePage = ({
     getAgent(initialAgentId)
       .then((agent) => {
         if (cancelled) return;
-        const source = agent.source;
-        setFormData((prev) => ({
-          ...prev,
-          agentMounts: [
-            ...prev.agentMounts,
-            {
-              agent_id: agent.id,
-              agent_name: agent.name,
-              agent_path: "",
-              source_type: source?.type,
-              version: agent.version,
-              package_name:
-                source?.type === "npm"
-                  ? source.npm?.package_name
-                  : source?.type === "pip"
-                    ? source.pip?.package_name
-                    : undefined,
-            },
-          ],
-        }));
+        setFormData((prev) => {
+          // Skip if this agent is already mounted
+          if (prev.agentMounts.some((m) => m.agent_id === agent.id)) {
+            return prev;
+          }
+          const source = agent.source;
+          const sourceType = source?.type;
+          const needsPath = sourceType === "git" || sourceType === "object";
+          return {
+            ...prev,
+            agentMounts: [
+              ...prev.agentMounts,
+              {
+                agent_id: agent.id,
+                agent_name: agent.name,
+                agent_path: needsPath ? getDefaultAgentMountPath(agent) : "",
+                source_type: sourceType,
+                version: agent.version,
+                package_name:
+                  sourceType === "npm"
+                    ? source?.npm?.package_name
+                    : sourceType === "pip"
+                      ? source?.pip?.package_name
+                      : undefined,
+              },
+            ],
+          };
+        });
       })
       .catch(() => {
         /* silently ignore — agent may not be accessible */

--- a/src/components/DevboxCreatePage.tsx
+++ b/src/components/DevboxCreatePage.tsx
@@ -2549,7 +2549,9 @@ export const DevboxCreatePage = ({
 
       {loadAgentError && (
         <Box paddingX={2} marginBottom={1}>
-          <Text color={colors.warning}>{figures.warning} {loadAgentError}</Text>
+          <Text color={colors.warning}>
+            {figures.warning} {loadAgentError}
+          </Text>
         </Box>
       )}
 

--- a/src/screens/AgentDetailScreen.tsx
+++ b/src/screens/AgentDetailScreen.tsx
@@ -28,7 +28,7 @@ interface AgentDetailScreenProps {
 }
 
 export function AgentDetailScreen({ agentId }: AgentDetailScreenProps) {
-  const { goBack } = useNavigation();
+  const { goBack, navigate } = useNavigation();
 
   const {
     data: agent,
@@ -191,20 +191,31 @@ export function AgentDetailScreen({ agentId }: AgentDetailScreenProps) {
   }
 
   const isPublic = agent.is_public;
-  const operations: ResourceOperation[] = isPublic
-    ? []
-    : [
-        {
-          key: "delete",
-          label: "Delete Agent",
-          color: colors.error,
-          icon: figures.cross,
-          shortcut: "d",
-        },
-      ];
+  const operations: ResourceOperation[] = [
+    {
+      key: "create-devbox",
+      label: "Create Devbox with Agent",
+      color: colors.success,
+      icon: figures.play,
+      shortcut: "n",
+    },
+    ...(isPublic
+      ? []
+      : [
+          {
+            key: "delete",
+            label: "Delete Agent",
+            color: colors.error,
+            icon: figures.cross,
+            shortcut: "d",
+          },
+        ]),
+  ];
 
   const handleOperation = (operation: string) => {
-    if (operation === "delete") {
+    if (operation === "create-devbox") {
+      navigate("devbox-create", { agentId: agent.id });
+    } else if (operation === "delete") {
       setShowDeleteConfirm(true);
     }
   };

--- a/src/screens/AgentDetailScreen.tsx
+++ b/src/screens/AgentDetailScreen.tsx
@@ -190,6 +190,7 @@ export function AgentDetailScreen({ agentId }: AgentDetailScreenProps) {
     }
   }
 
+  // "n" is safe here — detail screens don't use n/p pagination keys
   const isPublic = agent.is_public;
   const operations: ResourceOperation[] = [
     {

--- a/src/screens/DevboxCreateScreen.tsx
+++ b/src/screens/DevboxCreateScreen.tsx
@@ -21,6 +21,7 @@ export function DevboxCreateScreen() {
       onCreate={handleCreate}
       initialBlueprintId={params.blueprintId}
       initialSnapshotId={params.snapshotId}
+      initialAgentId={params.agentId}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Adds "Create Devbox with Agent" action (`[n]` shortcut) on agent detail screen
- Pre-populates the devbox create form with the selected agent mounted
- Available for both public and private agents

## Test plan
- [ ] TUI: navigate to agent detail, press `[n]` to create devbox with agent pre-mounted
- [ ] `[c]` still copies the agent ID (no shortcut conflict)
- [ ] Works for both public and private agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)