### PR TITLE
feat: add --public flag to agent create, fix object upload --public

### DIFF
--- a/src/commands/agent/create.ts
+++ b/src/commands/agent/create.ts
@@ -15,6 +15,7 @@ interface CreateOptions {
   ref?: string;
   objectId?: string;
   setupCommands?: string[];
+  public?: boolean;
   output?: string;
 }
 
@@ -104,6 +105,7 @@ export async function createAgentCommand(
     const agent = await createAgent({
       name: options.name,
       ...(options.agentVersion ? { version: options.agentVersion } : {}),
+      ...(options.public ? { is_public: true } : {}),
       source: { type: sourceType, [sourceType]: sourceOptions },
     });
 

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -241,7 +241,8 @@ export async function uploadObject(options: UploadObjectOptions) {
     const createResponse = await client.objects.create({
       name,
       content_type: detectedContentType,
-    });
+      ...(options.public ? { is_public: true } : {}),
+    } as any);
 
     // Step 2: Upload the file
     const uploadResponse = await fetch(createResponse.upload_url!, {

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -258,6 +258,7 @@ export async function listPublicAgents(
 export interface CreateAgentOptions {
   name: string;
   version?: string;
+  is_public?: boolean;
   source?: {
     type: string;
     npm?: {
@@ -280,10 +281,11 @@ export interface CreateAgentOptions {
  */
 export async function createAgent(options: CreateAgentOptions): Promise<Agent> {
   const client = getClient();
-  const { version, ...rest } = options;
+  const { version, is_public, ...rest } = options;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const params: any = { ...rest };
   if (version) params.version = version;
+  if (is_public !== undefined) params.is_public = is_public;
   return client.agents.create(params);
 }
 

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,10 +1,19 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { VERSION } from "../version.js";
 import { createDevbox } from "../commands/devbox/create.js";
 import { listDevboxes } from "../commands/devbox/list.js";
 import { deleteDevbox } from "../commands/devbox/delete.js";
 import { execCommand } from "../commands/devbox/exec.js";
 import { uploadFile } from "../commands/devbox/upload.js";
+import { runloopBaseDomain } from "./config.js";
+
+function publicOption(description: string): Option {
+  const opt = new Option("--public", description);
+  if (runloopBaseDomain() === "runloop.ai") {
+    opt.hideHelp();
+  }
+  return opt;
+}
 
 /**
  * Creates and configures the Commander program with all commands.
@@ -657,7 +666,7 @@ export function createProgram(): Command {
       "--content-type <type>",
       "Content type: unspecified|text|binary|gzip|tar|tgz",
     )
-    .option("--public", "Make object publicly accessible")
+    .addOption(publicOption("Make object publicly accessible"))
     .option(
       "-o, --output [format]",
       "Output format: text|json|yaml (default: text)",
@@ -1210,6 +1219,7 @@ export function createProgram(): Command {
       "--setup-commands <commands...>",
       "Setup commands to run after installation",
     )
+    .addOption(publicOption("Make agent publicly accessible"))
     .option(
       "-o, --output [format]",
       "Output format: text|json|yaml (default: text)",


### PR DESCRIPTION
## Description

Add a `--public` option to `rli agent create` and fix the existing broken `--public` on `rli object upload` so both pass `is_public: true` to their respective create API endpoints. The `is_public` field exists on the API but is absent from the SDK/OpenAPI spec, so this is useful for internal dev/staging use, or D2VPC customers who own their own platform and can upload whatever public stuff they want.

Both `--public` flags are hidden from `--help` when `RUNLOOP_BASE_URL` is unset or points to the default `runloop.ai`, and become visible when a custom base URL is configured.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `rli agent create --public` sets `is_public: true` in the agent create request
- `rli object upload --public` now actually passes `is_public: true` to the object create request (was previously defined but never sent)
- Both `--public` options are conditionally hidden from `--help` via a shared `publicOption()` helper that checks `runloopBaseDomain()`

## Testing

- [x] I have tested locally
- [x] All existing tests pass