### PR TITLE
feat: support multi-path tar/tgz archive creation in obj upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ rli blueprint from-dockerfile            # Create a blueprint from a Dockerfile 
 rli object list                          # List objects
 rli object get <id>                      # Get object details
 rli object download <id> <path>          # Download object to local file
-rli object upload <path>                 # Upload a file as an object
+rli object upload <paths...>             # Upload file(s) or directory as an obj...
 rli object delete <id>                   # Delete an object (irreversible)
 ```
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@runloop/api-client": "1.16.0",
     "@types/express": "5.0.6",
     "adm-zip": "0.5.16",
+    "tar": "^7.5.13",
     "chalk": "5.6.2",
     "commander": "14.0.2",
     "conf": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@runloop/api-client": "1.16.0",
     "@types/express": "5.0.6",
     "adm-zip": "0.5.16",
-    "tar": "^7.5.13",
     "chalk": "5.6.2",
     "commander": "14.0.2",
     "conf": "15.1.0",
@@ -89,6 +88,7 @@
     "ink-link": "5.0.0",
     "ink-spinner": "5.0.0",
     "ink-text-input": "6.0.0",
+    "nanotar": "0.3.0",
     "react": "19.2.0",
     "yaml": "2.8.3",
     "zustand": "5.0.10"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "ink-link": "5.0.0",
     "ink-spinner": "5.0.0",
     "ink-text-input": "6.0.0",
-    "nanotar": "0.3.0",
+    "nanotar": "^0.3.0",
     "react": "19.2.0",
     "yaml": "2.8.3",
     "zustand": "5.0.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react:
         specifier: 19.2.0
         version: 19.2.0
+      tar:
+        specifier: ^7.5.13
+        version: 7.5.13
       yaml:
         specifier: 2.8.3
         version: 2.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,12 +86,12 @@ importers:
       ink-text-input:
         specifier: 6.0.0
         version: 6.0.0(ink@6.6.0(@types/react@19.2.10)(react@19.2.0))(react@19.2.0)
+      nanotar:
+        specifier: 0.3.0
+        version: 0.3.0
       react:
         specifier: 19.2.0
         version: 19.2.0
-      tar:
-        specifier: ^7.5.13
-        version: 7.5.13
       yaml:
         specifier: 2.8.3
         version: 2.8.3
@@ -2360,6 +2360,9 @@ packages:
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  nanotar@0.3.0:
+    resolution: {integrity: sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -5916,6 +5919,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@1.0.0: {}
+
+  nanotar@0.3.0: {}
 
   natural-compare@1.4.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
         specifier: 6.0.0
         version: 6.0.0(ink@6.6.0(@types/react@19.2.10)(react@19.2.0))(react@19.2.0)
       nanotar:
-        specifier: 0.3.0
+        specifier: ^0.3.0
         version: 0.3.0
       react:
         specifier: 19.2.0

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -2,8 +2,8 @@
  * Upload object command
  */
 
-import { lstat, readFile, readdir, stat } from "fs/promises";
-import { extname, relative, resolve } from "path";
+import { lstat, readFile, readdir } from "fs/promises";
+import { basename, dirname, extname, relative, resolve } from "path";
 import { createTar, createTarGzip } from "nanotar";
 import type { TarFileInput } from "nanotar";
 import { getClient } from "../../utils/client.js";
@@ -38,26 +38,34 @@ const CONTENT_TYPE_MAP: Record<string, ContentType> = {
  * Recursively collect all files and directories under the given paths into
  * nanotar entries. Normalizes permissions: uid/gid 1000, directories and
  * executable files get mode 755, everything else gets 644. Preserves mtime.
+ *
+ * Entry names are always relative to `archiveRoot` and never contain leading
+ * `../` segments, preventing path traversal in the generated archive.
  */
 async function collectEntries(
   paths: string[],
-  cwd: string,
+  archiveRoot: string,
 ): Promise<TarFileInput[]> {
   const entries: TarFileInput[] = [];
 
   for (const p of paths) {
     const absPath = resolve(p);
-    const relPath = relative(cwd, absPath);
+    let relPath = relative(archiveRoot, absPath);
+
+    // Guard against path traversal: entry names must not escape the archive root
+    if (relPath.startsWith("..")) {
+      relPath = basename(absPath);
+    }
 
     let stats;
     try {
       stats = await lstat(absPath);
-    } catch {
-      throw new Error(`Cannot read path: ${relPath}`);
+    } catch (err) {
+      throw new Error(`Cannot read path: ${relPath}`, { cause: err });
     }
 
     if (stats.isSymbolicLink()) {
-      console.error(`Skipping symlink: ${relPath}`);
+      console.warn(`Warning: Skipping symlink: ${relPath}`);
       continue;
     }
 
@@ -68,21 +76,22 @@ async function collectEntries(
           mode: "755",
           uid: 1000,
           gid: 1000,
+          // nanotar expects mtime in milliseconds and converts to seconds internally
           mtime: stats.mtimeMs,
         },
       });
       const children = await readdir(absPath);
       const childPaths = children.map((c) => resolve(absPath, c));
       if (childPaths.length > 0) {
-        entries.push(...(await collectEntries(childPaths, cwd)));
+        entries.push(...(await collectEntries(childPaths, archiveRoot)));
       }
     } else {
       const isExecutable = (stats.mode & 0o111) !== 0;
       let data;
       try {
         data = await readFile(absPath);
-      } catch {
-        throw new Error(`Cannot read file: ${relPath}`);
+      } catch (err) {
+        throw new Error(`Cannot read file: ${relPath}`, { cause: err });
       }
       entries.push({
         name: relPath,
@@ -91,6 +100,7 @@ async function collectEntries(
           mode: isExecutable ? "755" : "644",
           uid: 1000,
           gid: 1000,
+          // nanotar expects mtime in milliseconds and converts to seconds internally
           mtime: stats.mtimeMs,
         },
       });
@@ -101,17 +111,39 @@ async function collectEntries(
 }
 
 /**
+ * Compute the deepest common directory for a list of absolute paths.
+ * Used as the archive root so entry names are always relative and safe.
+ */
+function commonAncestor(absPaths: string[]): string {
+  if (absPaths.length === 0) return process.cwd();
+  if (absPaths.length === 1) return dirname(absPaths[0]);
+  const parts = absPaths.map((p) => p.split("/"));
+  const common: string[] = [];
+  for (let i = 0; i < parts[0].length; i++) {
+    const segment = parts[0][i];
+    if (parts.every((p) => p[i] === segment)) {
+      common.push(segment);
+    } else {
+      break;
+    }
+  }
+  return common.join("/") || "/";
+}
+
+/**
  * Create a tar (or tgz) archive as a Buffer from the given filesystem paths.
  *
  * Walks directories recursively and normalizes all entries to uid/gid 1000,
  * mode 644 (non-executable files) or 755 (executable files and directories).
+ * Entry names are relative to the common ancestor of the provided paths.
  */
 export async function createTarBuffer(
   paths: string[],
   gzip: boolean,
 ): Promise<Buffer> {
-  const cwd = process.cwd();
-  const entries = await collectEntries(paths, cwd);
+  const absPaths = paths.map((p) => resolve(p));
+  const archiveRoot = commonAncestor(absPaths);
+  const entries = await collectEntries(paths, archiveRoot);
 
   if (gzip) {
     const data = await createTarGzip(entries);
@@ -132,11 +164,18 @@ export async function uploadObject(options: UploadObjectOptions) {
       return;
     }
 
-    // Validate all paths exist
-    const statsMap = new Map<string, Awaited<ReturnType<typeof stat>>>();
+    // Validate all paths exist (use lstat to match collectEntries and detect symlinks)
+    const statsMap = new Map<string, Awaited<ReturnType<typeof lstat>>>();
     for (const p of paths) {
       try {
-        statsMap.set(p, await stat(p));
+        const s = await lstat(p);
+        if (s.isSymbolicLink()) {
+          outputError(
+            `Path is a symlink: ${p}. Resolve the symlink or pass the target path directly.`,
+          );
+          return;
+        }
+        statsMap.set(p, s);
       } catch {
         outputError(`Path does not exist: ${p}`);
         return;
@@ -144,8 +183,9 @@ export async function uploadObject(options: UploadObjectOptions) {
     }
 
     const isTarType = contentType === "tar" || contentType === "tgz";
-    const singlePath = paths.length === 1;
-    const singleIsDir = singlePath && statsMap.get(paths[0])!.isDirectory();
+    const isSinglePath = paths.length === 1;
+    const firstStats = isSinglePath ? statsMap.get(paths[0])! : undefined;
+    const singleIsDir = isSinglePath && firstStats!.isDirectory();
 
     // Multi-path requires tar/tgz content type
     if (paths.length > 1 && !isTarType) {
@@ -176,14 +216,13 @@ export async function uploadObject(options: UploadObjectOptions) {
       fileSize = fileBuffer.length;
     } else {
       // Single file upload (existing behavior)
-      const singlePath = paths[0];
-      const stats = statsMap.get(singlePath)!;
-      fileBuffer = await readFile(singlePath);
-      fileSize = Number(stats.size);
+      const filePath = paths[0];
+      fileBuffer = await readFile(filePath);
+      fileSize = Number(firstStats!.size);
 
       detectedContentType = contentType as ContentType;
       if (!detectedContentType) {
-        const ext = extname(singlePath).toLowerCase();
+        const ext = extname(filePath).toLowerCase();
         detectedContentType = CONTENT_TYPE_MAP[ext] || "unspecified";
       }
     }

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -2,7 +2,7 @@
  * Upload object command
  */
 
-import { readFile, readdir, stat } from "fs/promises";
+import { lstat, readFile, readdir, stat } from "fs/promises";
 import { extname, relative, resolve } from "path";
 import { createTar, createTarGzip } from "nanotar";
 import type { TarFileInput } from "nanotar";
@@ -48,7 +48,18 @@ async function collectEntries(
   for (const p of paths) {
     const absPath = resolve(p);
     const relPath = relative(cwd, absPath);
-    const stats = await stat(absPath);
+
+    let stats;
+    try {
+      stats = await lstat(absPath);
+    } catch {
+      throw new Error(`Cannot read path: ${relPath}`);
+    }
+
+    if (stats.isSymbolicLink()) {
+      console.error(`Skipping symlink: ${relPath}`);
+      continue;
+    }
 
     if (stats.isDirectory()) {
       entries.push({
@@ -67,9 +78,15 @@ async function collectEntries(
       }
     } else {
       const isExecutable = (stats.mode & 0o111) !== 0;
+      let data;
+      try {
+        data = await readFile(absPath);
+      } catch {
+        throw new Error(`Cannot read file: ${relPath}`);
+      }
       entries.push({
         name: relPath,
-        data: await readFile(absPath),
+        data,
         attrs: {
           mode: isExecutable ? "755" : "644",
           uid: 1000,

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -3,7 +3,7 @@
  */
 
 import { lstat, readFile, readdir } from "fs/promises";
-import { basename, dirname, extname, relative, resolve } from "path";
+import { basename, dirname, extname, relative, resolve, sep } from "path";
 import { createTar, createTarGzip } from "nanotar";
 import type { TarFileInput } from "nanotar";
 import { getClient } from "../../utils/client.js";
@@ -45,6 +45,7 @@ const CONTENT_TYPE_MAP: Record<string, ContentType> = {
 async function collectEntries(
   paths: string[],
   archiveRoot: string,
+  precomputedStats?: Map<string, Awaited<ReturnType<typeof lstat>>>,
 ): Promise<TarFileInput[]> {
   const entries: TarFileInput[] = [];
 
@@ -57,16 +58,19 @@ async function collectEntries(
       relPath = basename(absPath);
     }
 
-    let stats;
-    try {
-      stats = await lstat(absPath);
-    } catch (err) {
-      throw new Error(`Cannot read path: ${relPath}`, { cause: err });
+    let stats = precomputedStats?.get(absPath);
+    if (!stats) {
+      try {
+        stats = await lstat(absPath);
+      } catch (err) {
+        throw new Error(`Cannot read path: ${relPath}`, { cause: err });
+      }
     }
 
     if (stats.isSymbolicLink()) {
-      console.warn(`Warning: Skipping symlink: ${relPath}`);
-      continue;
+      throw new Error(
+        `Path is a symlink: ${relPath}. Resolve the symlink or pass the target path directly.`,
+      );
     }
 
     if (stats.isDirectory()) {
@@ -117,7 +121,7 @@ async function collectEntries(
 function commonAncestor(absPaths: string[]): string {
   if (absPaths.length === 0) return process.cwd();
   if (absPaths.length === 1) return dirname(absPaths[0]);
-  const parts = absPaths.map((p) => p.split("/"));
+  const parts = absPaths.map((p) => p.split(sep));
   const common: string[] = [];
   for (let i = 0; i < parts[0].length; i++) {
     const segment = parts[0][i];
@@ -127,7 +131,7 @@ function commonAncestor(absPaths: string[]): string {
       break;
     }
   }
-  return common.join("/") || "/";
+  return common.join(sep) || sep;
 }
 
 /**
@@ -140,10 +144,11 @@ function commonAncestor(absPaths: string[]): string {
 export async function createTarBuffer(
   paths: string[],
   gzip: boolean,
+  precomputedStats?: Map<string, Awaited<ReturnType<typeof lstat>>>,
 ): Promise<Buffer> {
   const absPaths = paths.map((p) => resolve(p));
   const archiveRoot = commonAncestor(absPaths);
-  const entries = await collectEntries(paths, archiveRoot);
+  const entries = await collectEntries(paths, archiveRoot, precomputedStats);
 
   if (gzip) {
     const data = await createTarGzip(entries);
@@ -165,6 +170,7 @@ export async function uploadObject(options: UploadObjectOptions) {
     }
 
     // Validate all paths exist (use lstat to match collectEntries and detect symlinks)
+    // Key by resolved absolute path so collectEntries can reuse stats
     const statsMap = new Map<string, Awaited<ReturnType<typeof lstat>>>();
     for (const p of paths) {
       try {
@@ -175,7 +181,7 @@ export async function uploadObject(options: UploadObjectOptions) {
           );
           return;
         }
-        statsMap.set(p, s);
+        statsMap.set(resolve(p), s);
       } catch {
         outputError(`Path does not exist: ${p}`);
         return;
@@ -184,7 +190,9 @@ export async function uploadObject(options: UploadObjectOptions) {
 
     const isTarType = contentType === "tar" || contentType === "tgz";
     const isSinglePath = paths.length === 1;
-    const firstStats = isSinglePath ? statsMap.get(paths[0])! : undefined;
+    const firstStats = isSinglePath
+      ? statsMap.get(resolve(paths[0]))!
+      : undefined;
     const singleIsDir = isSinglePath && firstStats!.isDirectory();
 
     // Multi-path requires tar/tgz content type
@@ -211,7 +219,7 @@ export async function uploadObject(options: UploadObjectOptions) {
 
     if (shouldCreateArchive) {
       const gzip = contentType === "tgz";
-      fileBuffer = await createTarBuffer(paths, gzip);
+      fileBuffer = await createTarBuffer(paths, gzip, statsMap);
       detectedContentType = contentType as ContentType;
       fileSize = fileBuffer.length;
     } else {

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -81,7 +81,7 @@ async function collectEntries(
           uid: 1000,
           gid: 1000,
           // nanotar expects mtime in milliseconds and converts to seconds internally
-          mtime: stats.mtimeMs,
+          mtime: Number(stats.mtimeMs),
         },
       });
       const children = await readdir(absPath);
@@ -90,7 +90,7 @@ async function collectEntries(
         entries.push(...(await collectEntries(childPaths, archiveRoot)));
       }
     } else {
-      const isExecutable = (stats.mode & 0o111) !== 0;
+      const isExecutable = (Number(stats.mode) & 0o111) !== 0;
       let data;
       try {
         data = await readFile(absPath);
@@ -105,7 +105,7 @@ async function collectEntries(
           uid: 1000,
           gid: 1000,
           // nanotar expects mtime in milliseconds and converts to seconds internally
-          mtime: stats.mtimeMs,
+          mtime: Number(stats.mtimeMs),
         },
       });
     }

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -2,13 +2,17 @@
  * Upload object command
  */
 
-import { readFile, stat } from "fs/promises";
-import { extname } from "path";
+import { readFile, stat, unlink } from "fs/promises";
+import { tmpdir } from "os";
+import { basename, extname, relative, resolve } from "path";
+import { randomUUID } from "crypto";
+import { join } from "path";
+import * as tar from "tar";
 import { getClient } from "../../utils/client.js";
 import { output, outputError } from "../../utils/output.js";
 
 interface UploadObjectOptions {
-  path: string;
+  paths: string[];
   name: string;
   contentType?: string;
   public?: boolean;
@@ -32,24 +36,102 @@ const CONTENT_TYPE_MAP: Record<string, ContentType> = {
   ".tar.gz": "tgz",
 };
 
+export async function createTarBuffer(
+  paths: string[],
+  gzip: boolean,
+): Promise<Buffer> {
+  const cwd = process.cwd();
+  const relativePaths = paths.map((p) => relative(cwd, resolve(p)));
+
+  const tmpFile = join(
+    tmpdir(),
+    `rl-upload-${randomUUID()}.${gzip ? "tgz" : "tar"}`,
+  );
+
+  await tar.create(
+    {
+      file: tmpFile,
+      gzip,
+      cwd,
+    },
+    relativePaths,
+  );
+
+  const buffer = await readFile(tmpFile);
+  await unlink(tmpFile);
+  return buffer;
+}
+
 export async function uploadObject(options: UploadObjectOptions) {
   try {
     const client = getClient();
+    const { paths, name, contentType, output: outputFormat } = options;
 
-    // Check if file exists and get stats
-    const stats = await stat(options.path);
-    const fileBuffer = await readFile(options.path);
+    if (paths.length === 0) {
+      outputError("At least one path is required");
+      return;
+    }
 
-    // Auto-detect content type if not provided
-    let detectedContentType: ContentType = options.contentType as ContentType;
-    if (!detectedContentType) {
-      const ext = extname(options.path).toLowerCase();
-      detectedContentType = CONTENT_TYPE_MAP[ext] || "unspecified";
+    // Validate all paths exist
+    const statsMap = new Map<string, Awaited<ReturnType<typeof stat>>>();
+    for (const p of paths) {
+      try {
+        statsMap.set(p, await stat(p));
+      } catch {
+        outputError(`Path does not exist: ${p}`);
+        return;
+      }
+    }
+
+    const isTarType = contentType === "tar" || contentType === "tgz";
+    const singlePath = paths.length === 1;
+    const singleIsDir = singlePath && statsMap.get(paths[0])!.isDirectory();
+
+    // Multi-path requires tar/tgz content type
+    if (paths.length > 1 && !isTarType) {
+      outputError(
+        "Multiple paths require --content-type tar or --content-type tgz",
+      );
+      return;
+    }
+
+    // Directory without tar/tgz type
+    if (singleIsDir && !isTarType) {
+      outputError(
+        "Cannot upload a directory directly. Use --content-type tar or --content-type tgz to create an archive.",
+      );
+      return;
+    }
+
+    let fileBuffer: Buffer;
+    let detectedContentType: ContentType;
+    let fileSize: number;
+
+    const shouldCreateArchive =
+      isTarType && (paths.length > 1 || singleIsDir);
+
+    if (shouldCreateArchive) {
+      const gzip = contentType === "tgz";
+      fileBuffer = await createTarBuffer(paths, gzip);
+      detectedContentType = contentType as ContentType;
+      fileSize = fileBuffer.length;
+    } else {
+      // Single file upload (existing behavior)
+      const singlePath = paths[0];
+      const stats = statsMap.get(singlePath)!;
+      fileBuffer = await readFile(singlePath);
+      fileSize = Number(stats.size);
+
+      detectedContentType = contentType as ContentType;
+      if (!detectedContentType) {
+        const ext = extname(singlePath).toLowerCase();
+        detectedContentType = CONTENT_TYPE_MAP[ext] || "unspecified";
+      }
     }
 
     // Step 1: Create the object
     const createResponse = await client.objects.create({
-      name: options.name,
+      name,
       content_type: detectedContentType,
     });
 
@@ -71,16 +153,16 @@ export async function uploadObject(options: UploadObjectOptions) {
 
     const result = {
       id: createResponse.id,
-      name: options.name,
+      name,
       contentType: detectedContentType,
-      size: stats.size,
+      size: fileSize,
     };
 
     // Default: just output the ID for easy scripting
-    if (!options.output || options.output === "text") {
+    if (!outputFormat || outputFormat === "text") {
       console.log(result.id);
     } else {
-      output(result, { format: options.output, defaultFormat: "json" });
+      output(result, { format: outputFormat, defaultFormat: "json" });
     }
   } catch (error) {
     outputError("Failed to upload object", error);

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -4,9 +4,8 @@
 
 import { readFile, stat, unlink } from "fs/promises";
 import { tmpdir } from "os";
-import { basename, extname, relative, resolve } from "path";
+import { extname, join, relative, resolve } from "path";
 import { randomUUID } from "crypto";
-import { join } from "path";
 import * as tar from "tar";
 import { getClient } from "../../utils/client.js";
 import { output, outputError } from "../../utils/output.js";

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -107,8 +107,7 @@ export async function uploadObject(options: UploadObjectOptions) {
     let detectedContentType: ContentType;
     let fileSize: number;
 
-    const shouldCreateArchive =
-      isTarType && (paths.length > 1 || singleIsDir);
+    const shouldCreateArchive = isTarType && (paths.length > 1 || singleIsDir);
 
     if (shouldCreateArchive) {
       const gzip = contentType === "tgz";

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -3,7 +3,7 @@
  */
 
 import { lstat, readFile, readdir } from "fs/promises";
-import { basename, dirname, extname, relative, resolve, sep } from "path";
+import { dirname, extname, relative, resolve, sep } from "path";
 import { createTar, createTarGzip } from "nanotar";
 import type { TarFileInput } from "nanotar";
 import { getClient } from "../../utils/client.js";
@@ -55,7 +55,9 @@ async function collectEntries(
 
     // Guard against path traversal: entry names must not escape the archive root
     if (relPath.startsWith("..")) {
-      relPath = basename(absPath);
+      throw new Error(
+        `Path "${absPath}" is outside the archive root "${archiveRoot}". All paths must share a common ancestor directory.`,
+      );
     }
 
     let stats = precomputedStats?.get(absPath);

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -35,6 +35,15 @@ const CONTENT_TYPE_MAP: Record<string, ContentType> = {
   ".tar.gz": "tgz",
 };
 
+/**
+ * Create a tar (or tgz) archive as a Buffer from the given filesystem paths.
+ *
+ * Uses a temp file because the `tar` package's `tar.create()` only supports
+ * writing to a file path or to a stream — it has no "return a buffer"
+ * option. We write to a temp file, read it back into memory, then delete
+ * the temp file. This is the simplest reliable approach for producing a
+ * single Buffer suitable for an HTTP PUT body.
+ */
 export async function createTarBuffer(
   paths: string[],
   gzip: boolean,

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -2,11 +2,10 @@
  * Upload object command
  */
 
-import { readFile, stat, unlink } from "fs/promises";
-import { tmpdir } from "os";
-import { extname, join, relative, resolve } from "path";
-import { randomUUID } from "crypto";
-import * as tar from "tar";
+import { readFile, readdir, stat } from "fs/promises";
+import { extname, relative, resolve } from "path";
+import { createTar, createTarGzip } from "nanotar";
+import type { TarFileInput } from "nanotar";
 import { getClient } from "../../utils/client.js";
 import { output, outputError } from "../../utils/output.js";
 
@@ -36,38 +35,74 @@ const CONTENT_TYPE_MAP: Record<string, ContentType> = {
 };
 
 /**
+ * Recursively collect all files and directories under the given paths into
+ * nanotar entries. Normalizes permissions: uid/gid 1000, directories and
+ * executable files get mode 755, everything else gets 644. Preserves mtime.
+ */
+async function collectEntries(
+  paths: string[],
+  cwd: string,
+): Promise<TarFileInput[]> {
+  const entries: TarFileInput[] = [];
+
+  for (const p of paths) {
+    const absPath = resolve(p);
+    const relPath = relative(cwd, absPath);
+    const stats = await stat(absPath);
+
+    if (stats.isDirectory()) {
+      entries.push({
+        name: relPath.endsWith("/") ? relPath : relPath + "/",
+        attrs: {
+          mode: "755",
+          uid: 1000,
+          gid: 1000,
+          mtime: stats.mtimeMs,
+        },
+      });
+      const children = await readdir(absPath);
+      const childPaths = children.map((c) => resolve(absPath, c));
+      if (childPaths.length > 0) {
+        entries.push(...(await collectEntries(childPaths, cwd)));
+      }
+    } else {
+      const isExecutable = (stats.mode & 0o111) !== 0;
+      entries.push({
+        name: relPath,
+        data: await readFile(absPath),
+        attrs: {
+          mode: isExecutable ? "755" : "644",
+          uid: 1000,
+          gid: 1000,
+          mtime: stats.mtimeMs,
+        },
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
  * Create a tar (or tgz) archive as a Buffer from the given filesystem paths.
  *
- * Uses a temp file because the `tar` package's `tar.create()` only supports
- * writing to a file path or to a stream — it has no "return a buffer"
- * option. We write to a temp file, read it back into memory, then delete
- * the temp file. This is the simplest reliable approach for producing a
- * single Buffer suitable for an HTTP PUT body.
+ * Walks directories recursively and normalizes all entries to uid/gid 1000,
+ * mode 644 (non-executable files) or 755 (executable files and directories).
  */
 export async function createTarBuffer(
   paths: string[],
   gzip: boolean,
 ): Promise<Buffer> {
   const cwd = process.cwd();
-  const relativePaths = paths.map((p) => relative(cwd, resolve(p)));
+  const entries = await collectEntries(paths, cwd);
 
-  const tmpFile = join(
-    tmpdir(),
-    `rl-upload-${randomUUID()}.${gzip ? "tgz" : "tar"}`,
-  );
+  if (gzip) {
+    const data = await createTarGzip(entries);
+    return Buffer.from(data);
+  }
 
-  await tar.create(
-    {
-      file: tmpFile,
-      gzip,
-      cwd,
-    },
-    relativePaths,
-  );
-
-  const buffer = await readFile(tmpFile);
-  await unlink(tmpFile);
-  return buffer;
+  const data = createTar(entries);
+  return Buffer.from(data);
 }
 
 export async function uploadObject(options: UploadObjectOptions) {

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -84,7 +84,7 @@ async function collectEntries(
           mtime: Number(stats.mtimeMs),
         },
       });
-      const children = await readdir(absPath);
+      const children = (await readdir(absPath)).sort();
       const childPaths = children.map((c) => resolve(absPath, c));
       if (childPaths.length > 0) {
         entries.push(...(await collectEntries(childPaths, archiveRoot)));
@@ -226,7 +226,7 @@ export async function uploadObject(options: UploadObjectOptions) {
       // Single file upload (existing behavior)
       const filePath = paths[0];
       fileBuffer = await readFile(filePath);
-      fileSize = Number(firstStats!.size);
+      fileSize = fileBuffer.length;
 
       detectedContentType = contentType as ContentType;
       if (!detectedContentType) {

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -648,8 +648,10 @@ export function createProgram(): Command {
     });
 
   object
-    .command("upload <path>")
-    .description("Upload a file as an object")
+    .command("upload <paths...>")
+    .description(
+      "Upload file(s) or directory as an object. Multiple paths with --content-type tar|tgz creates an archive.",
+    )
     .option("--name <name>", "Object name (required)")
     .option(
       "--content-type <type>",
@@ -660,14 +662,16 @@ export function createProgram(): Command {
       "-o, --output [format]",
       "Output format: text|json|yaml (default: text)",
     )
-    .action(async (path, options) => {
+    .action(async (paths, options) => {
       const { uploadObject } = await import("../commands/object/upload.js");
       if (!options.output) {
         const { runInteractiveCommand } =
           await import("../utils/interactiveCommand.js");
-        await runInteractiveCommand(() => uploadObject({ path, ...options }));
+        await runInteractiveCommand(() =>
+          uploadObject({ paths, ...options }),
+        );
       } else {
-        await uploadObject({ path, ...options });
+        await uploadObject({ paths, ...options });
       }
     });
 

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -667,9 +667,7 @@ export function createProgram(): Command {
       if (!options.output) {
         const { runInteractiveCommand } =
           await import("../utils/interactiveCommand.js");
-        await runInteractiveCommand(() =>
-          uploadObject({ paths, ...options }),
-        );
+        await runInteractiveCommand(() => uploadObject({ paths, ...options }));
       } else {
         await uploadObject({ paths, ...options });
       }

--- a/tests/__tests__/commands/object/upload.test.ts
+++ b/tests/__tests__/commands/object/upload.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for object upload command - tar/tgz archive creation and validation
+ */
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import * as tar from "tar";
+
+// Mock client and output
+const mockCreate = jest.fn();
+const mockComplete = jest.fn();
+jest.unstable_mockModule("@/utils/client.js", () => ({
+  getClient: () => ({
+    objects: {
+      create: mockCreate,
+      complete: mockComplete,
+    },
+  }),
+}));
+
+const mockOutput = jest.fn();
+const mockOutputError = jest.fn();
+jest.unstable_mockModule("@/utils/output.js", () => ({
+  output: mockOutput,
+  outputError: mockOutputError,
+}));
+
+// Mock fetch for upload
+const mockFetch = jest.fn<typeof globalThis.fetch>();
+globalThis.fetch = mockFetch;
+
+describe("createTarBuffer", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    testDir = await mkdtemp(join(tmpdir(), "rl-upload-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("creates a valid tar buffer from multiple files", async () => {
+    await writeFile(join(testDir, "a.txt"), "hello");
+    await writeFile(join(testDir, "b.txt"), "world");
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer(
+      [join(testDir, "a.txt"), join(testDir, "b.txt")],
+      false,
+    );
+
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.length).toBeGreaterThan(0);
+
+    // Verify the tar contains the expected files
+    const entries: string[] = [];
+    const extractDir = await mkdtemp(join(tmpdir(), "rl-extract-test-"));
+    await tar.extract({ file: undefined, cwd: extractDir, sync: false }, undefined);
+
+    // Write buffer to temp file and list contents
+    const tmpFile = join(testDir, "test.tar");
+    await writeFile(tmpFile, buffer);
+    await tar.list({
+      file: tmpFile,
+      onReadEntry: (entry) => {
+        entries.push(entry.path);
+      },
+    });
+
+    expect(entries.length).toBe(2);
+    await rm(extractDir, { recursive: true, force: true });
+  });
+
+  it("creates a valid tgz buffer (gzipped)", async () => {
+    await writeFile(join(testDir, "file.txt"), "compressed content");
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer(
+      [join(testDir, "file.txt")],
+      true,
+    );
+
+    expect(buffer).toBeInstanceOf(Buffer);
+    // Gzip magic bytes: 0x1f 0x8b
+    expect(buffer[0]).toBe(0x1f);
+    expect(buffer[1]).toBe(0x8b);
+  });
+
+  it("creates a tar from a directory", async () => {
+    const subDir = join(testDir, "mydir");
+    await mkdir(subDir);
+    await writeFile(join(subDir, "nested.txt"), "nested content");
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer([subDir], false);
+
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+});
+
+describe("uploadObject", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    testDir = await mkdtemp(join(tmpdir(), "rl-upload-test-"));
+    mockCreate.mockResolvedValue({
+      id: "obj_test123",
+      upload_url: "https://example.com/upload",
+    });
+    mockFetch.mockResolvedValue({ ok: true } as Response);
+    mockComplete.mockResolvedValue({});
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("uploads a single file with existing behavior", async () => {
+    const filePath = join(testDir, "test.txt");
+    await writeFile(filePath, "test content");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [filePath],
+      name: "test-object",
+    });
+
+    logSpy.mockRestore();
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "test-object",
+      content_type: "text",
+    });
+    expect(mockFetch).toHaveBeenCalled();
+    expect(mockComplete).toHaveBeenCalledWith("obj_test123");
+  });
+
+  it("errors when multiple paths given without tar/tgz content type", async () => {
+    const file1 = join(testDir, "a.txt");
+    const file2 = join(testDir, "b.txt");
+    await writeFile(file1, "a");
+    await writeFile(file2, "b");
+
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [file1, file2],
+      name: "test-object",
+      contentType: "text",
+    });
+
+    expect(mockOutputError).toHaveBeenCalledWith(
+      "Multiple paths require --content-type tar or --content-type tgz",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("errors when directory given without tar/tgz content type", async () => {
+    const dir = join(testDir, "mydir");
+    await mkdir(dir);
+
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [dir],
+      name: "test-object",
+    });
+
+    expect(mockOutputError).toHaveBeenCalledWith(
+      "Cannot upload a directory directly. Use --content-type tar or --content-type tgz to create an archive.",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("errors when path does not exist", async () => {
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [join(testDir, "nonexistent.txt")],
+      name: "test-object",
+    });
+
+    expect(mockOutputError).toHaveBeenCalledWith(
+      expect.stringContaining("Path does not exist"),
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates tar archive from multiple files when content type is tar", async () => {
+    const file1 = join(testDir, "a.txt");
+    const file2 = join(testDir, "b.txt");
+    await writeFile(file1, "file a");
+    await writeFile(file2, "file b");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [file1, file2],
+      name: "multi-file-archive",
+      contentType: "tar",
+    });
+
+    logSpy.mockRestore();
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "multi-file-archive",
+      content_type: "tar",
+    });
+    expect(mockFetch).toHaveBeenCalled();
+    expect(mockComplete).toHaveBeenCalledWith("obj_test123");
+  });
+
+  it("creates tgz archive from a directory when content type is tgz", async () => {
+    const dir = join(testDir, "mydir");
+    await mkdir(dir);
+    await writeFile(join(dir, "file.txt"), "content");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [dir],
+      name: "dir-archive",
+      contentType: "tgz",
+    });
+
+    logSpy.mockRestore();
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "dir-archive",
+      content_type: "tgz",
+    });
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("uploads single tar file as-is without creating archive", async () => {
+    const filePath = join(testDir, "existing.tar");
+    await writeFile(filePath, "fake tar content");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { uploadObject } = await import("@/commands/object/upload.js");
+    await uploadObject({
+      paths: [filePath],
+      name: "existing-archive",
+      contentType: "tar",
+    });
+
+    logSpy.mockRestore();
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "existing-archive",
+      content_type: "tar",
+    });
+    // Should upload the raw file content, not create a tar of the tar
+    const fetchCall = mockFetch.mock.calls[0];
+    const body = fetchCall[1]?.body as Buffer;
+    expect(body.toString()).toBe("fake tar content");
+  });
+});

--- a/tests/__tests__/commands/object/upload.test.ts
+++ b/tests/__tests__/commands/object/upload.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
-import { mkdtemp, writeFile, mkdir, rm, chmod, utimes } from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, chmod, utimes, symlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { parseTar } from "nanotar";
@@ -138,6 +138,18 @@ describe("createTarBuffer", () => {
     const entries = parseTar(buffer);
     const dir = entries.find((e) => e.name.endsWith("subdir/"));
     expect(dir?.attrs?.mode).toContain("755");
+  });
+
+  it("errors on symlinks inside a directory tree", async () => {
+    const subDir = join(testDir, "with-symlink");
+    await mkdir(subDir);
+    await writeFile(join(subDir, "real.txt"), "real content");
+    await symlink(join(subDir, "real.txt"), join(subDir, "link.txt"));
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    await expect(createTarBuffer([subDir], false)).rejects.toThrow(
+      /symlink/i,
+    );
   });
 
   it("preserves mtime from the filesystem", async () => {

--- a/tests/__tests__/commands/object/upload.test.ts
+++ b/tests/__tests__/commands/object/upload.test.ts
@@ -3,10 +3,10 @@
  */
 
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
-import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, chmod, utimes } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import * as tar from "tar";
+import { parseTar } from "nanotar";
 
 // Mock client and output
 const mockCreate = jest.fn();
@@ -56,23 +56,11 @@ describe("createTarBuffer", () => {
     expect(buffer).toBeInstanceOf(Buffer);
     expect(buffer.length).toBeGreaterThan(0);
 
-    // Verify the tar contains the expected files
-    const entries: string[] = [];
-    const extractDir = await mkdtemp(join(tmpdir(), "rl-extract-test-"));
-    await tar.extract({ file: undefined, cwd: extractDir, sync: false }, undefined);
-
-    // Write buffer to temp file and list contents
-    const tmpFile = join(testDir, "test.tar");
-    await writeFile(tmpFile, buffer);
-    await tar.list({
-      file: tmpFile,
-      onReadEntry: (entry) => {
-        entries.push(entry.path);
-      },
-    });
-
-    expect(entries.length).toBe(2);
-    await rm(extractDir, { recursive: true, force: true });
+    const entries = parseTar(buffer);
+    const names = entries.map((e) => e.name);
+    expect(names).toHaveLength(2);
+    expect(names.some((n) => n.endsWith("a.txt"))).toBe(true);
+    expect(names.some((n) => n.endsWith("b.txt"))).toBe(true);
   });
 
   it("creates a valid tgz buffer (gzipped)", async () => {
@@ -100,6 +88,74 @@ describe("createTarBuffer", () => {
 
     expect(buffer).toBeInstanceOf(Buffer);
     expect(buffer.length).toBeGreaterThan(0);
+
+    const entries = parseTar(buffer);
+    const dirEntry = entries.find((e) => e.name.endsWith("mydir/"));
+    const fileEntry = entries.find((e) => e.name.endsWith("nested.txt"));
+    expect(dirEntry).toBeDefined();
+    expect(fileEntry).toBeDefined();
+  });
+
+  it("normalizes uid/gid to 1000 for all entries", async () => {
+    await writeFile(join(testDir, "file.txt"), "content");
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer([join(testDir, "file.txt")], false);
+
+    // Verify uid/gid by reading the raw tar header bytes directly.
+    // nanotar's parseTar has an octal parsing quirk, so read the raw field.
+    const uid = buffer.toString("ascii", 108, 115).replace(/\0/g, "").trim();
+    const gid = buffer.toString("ascii", 116, 123).replace(/\0/g, "").trim();
+    expect(parseInt(uid, 8)).toBe(1000);
+    expect(parseInt(gid, 8)).toBe(1000);
+  });
+
+  it("sets mode 644 for non-executable files and 755 for executable files", async () => {
+    const normalFile = join(testDir, "normal.txt");
+    const execFile = join(testDir, "script.sh");
+    await writeFile(normalFile, "data");
+    await writeFile(execFile, "#!/bin/sh\necho hi");
+    await chmod(execFile, 0o755);
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer([normalFile, execFile], false);
+
+    const entries = parseTar(buffer);
+    const normal = entries.find((e) => e.name.endsWith("normal.txt"));
+    const exec = entries.find((e) => e.name.endsWith("script.sh"));
+    expect(normal?.attrs?.mode).toContain("644");
+    expect(exec?.attrs?.mode).toContain("755");
+  });
+
+  it("sets mode 755 for directories", async () => {
+    const subDir = join(testDir, "subdir");
+    await mkdir(subDir);
+    await writeFile(join(subDir, "file.txt"), "content");
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer([subDir], false);
+
+    const entries = parseTar(buffer);
+    const dir = entries.find((e) => e.name.endsWith("subdir/"));
+    expect(dir?.attrs?.mode).toContain("755");
+  });
+
+  it("preserves mtime from the filesystem", async () => {
+    const filePath = join(testDir, "dated.txt");
+    await writeFile(filePath, "content");
+    // Set a known mtime: 2024-01-15T00:00:00Z
+    const knownTime = new Date("2024-01-15T00:00:00Z");
+    await utimes(filePath, knownTime, knownTime);
+
+    const { createTarBuffer } = await import("@/commands/object/upload.js");
+    const buffer = await createTarBuffer([filePath], false);
+
+    const entries = parseTar(buffer);
+    const entry = entries.find((e) => e.name.endsWith("dated.txt"));
+    expect(entry?.attrs?.mtime).toBeDefined();
+    // parseTar returns mtime in seconds (raw tar format)
+    const expectedSec = Math.floor(knownTime.getTime() / 1000);
+    expect(entry?.attrs?.mtime).toBe(expectedSec);
   });
 });
 


### PR DESCRIPTION
## Summary

If someone has a script to automatically create a tarball of files then upload the tar as an object, we can make it more convenient by doing the tar operations ourselves.

- **Multi-path upload**: Change `obj upload <path>` to `obj upload <paths...>` to accept multiple files/directories in a single command
- **Automatic tar/tgz archive creation**: When `--content-type tar|tgz` is specified with multiple paths or a single directory, the CLI creates the archive automatically before uploading. A single file with tar/tgz type uploads as-is.
- **Validation with helpful errors**: Multi-path without tar/tgz type errors with guidance. Directory without tar/tgz type errors with "use --content-type tar or tgz".
- **Permission normalization**: All tar entries are normalized to uid/gid 1000, mode 644 (non-executable files) or 755 (executable files and directories), regardless of source file permissions
- **mtime preservation**: File modification times are preserved from the filesystem
- **nanotar over tar**: Uses `nanotar` (~1KB, from unjs) instead of the `tar` package

## Decision matrix

| Content type | Input | Behavior |
|---|---|---|
| `tar`/`tgz` | multiple paths | create archive, upload |
| `tar`/`tgz` | single directory | create archive, upload |
| `tar`/`tgz` | single file | upload as-is |
| other | multiple paths | error |
| other | single directory | error |
| other | single file | existing behavior |

## Test plan

- [ ] `rli obj upload ./file.txt --name test --content-type text` — single file, existing behavior
- [ ] `rli obj upload ./dir --name test --content-type tar` — single dir, creates tar
- [ ] `rli obj upload ./dir --name test --content-type tgz` — single dir, creates tgz
- [ ] `rli obj upload ./a.txt ./b.txt ./dir --name test --content-type tar` — multi-path tar
- [ ] `rli obj upload ./a.txt ./b.txt --name test` — ERROR
- [ ] `rli obj upload ./dir --name test` — ERROR
- [ ] `rli obj upload ./file.tar --name test --content-type tar` — single file, uploads as-is
- [ ] Verify executable files get mode 755, non-executable get 644, dirs get 755
- [ ] Verify uid/gid are 1000 for all entries
- [ ] Verify mtime is preserved
- [ ] `pnpm test` — 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)