### PR TITLE
feat: add --public flag to agent create, fix object upload --public

### DIFF
--- a/src/commands/agent/create.ts
+++ b/src/commands/agent/create.ts
@@ -15,6 +15,7 @@ interface CreateOptions {
   ref?: string;
   objectId?: string;
   setupCommands?: string[];
+  public?: boolean;
   output?: string;
 }
 
@@ -104,6 +105,7 @@ export async function createAgentCommand(
     const agent = await createAgent({
       name: options.name,
       ...(options.agentVersion ? { version: options.agentVersion } : {}),
+      ...(options.public ? { is_public: true } : {}),
       source: { type: sourceType, [sourceType]: sourceOptions },
     });
 

--- a/src/commands/object/upload.ts
+++ b/src/commands/object/upload.ts
@@ -241,7 +241,8 @@ export async function uploadObject(options: UploadObjectOptions) {
     const createResponse = await client.objects.create({
       name,
       content_type: detectedContentType,
-    });
+      ...(options.public ? { is_public: true } : {}),
+    } as any);
 
     // Step 2: Upload the file
     const uploadResponse = await fetch(createResponse.upload_url!, {

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -258,6 +258,7 @@ export async function listPublicAgents(
 export interface CreateAgentOptions {
   name: string;
   version?: string;
+  is_public?: boolean;
   source?: {
     type: string;
     npm?: {
@@ -280,10 +281,11 @@ export interface CreateAgentOptions {
  */
 export async function createAgent(options: CreateAgentOptions): Promise<Agent> {
   const client = getClient();
-  const { version, ...rest } = options;
+  const { version, is_public, ...rest } = options;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const params: any = { ...rest };
   if (version) params.version = version;
+  if (is_public !== undefined) params.is_public = is_public;
   return client.agents.create(params);
 }
 

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,10 +1,19 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { VERSION } from "../version.js";
 import { createDevbox } from "../commands/devbox/create.js";
 import { listDevboxes } from "../commands/devbox/list.js";
 import { deleteDevbox } from "../commands/devbox/delete.js";
 import { execCommand } from "../commands/devbox/exec.js";
 import { uploadFile } from "../commands/devbox/upload.js";
+import { runloopBaseDomain } from "./config.js";
+
+function publicOption(description: string): Option {
+  const opt = new Option("--public", description);
+  if (runloopBaseDomain() === "runloop.ai") {
+    opt.hideHelp();
+  }
+  return opt;
+}
 
 /**
  * Creates and configures the Commander program with all commands.
@@ -657,7 +666,7 @@ export function createProgram(): Command {
       "--content-type <type>",
       "Content type: unspecified|text|binary|gzip|tar|tgz",
     )
-    .option("--public", "Make object publicly accessible")
+    .addOption(publicOption("Make object publicly accessible"))
     .option(
       "-o, --output [format]",
       "Output format: text|json|yaml (default: text)",
@@ -1210,6 +1219,7 @@ export function createProgram(): Command {
       "--setup-commands <commands...>",
       "Setup commands to run after installation",
     )
+    .addOption(publicOption("Make agent publicly accessible"))
     .option(
       "-o, --output [format]",
       "Output format: text|json|yaml (default: text)",


### PR DESCRIPTION
## Summary

- Add `--public` option to `rli agent create` that sets `is_public: true` in the create API request (field exists on the API but is absent from the SDK/OpenAPI spec)
- Fix the existing `--public` flag on `rli object upload` which was defined but never passed to the API
- Both `--public` flags are hidden from `--help` when `RUNLOOP_BASE_URL` is unset or points to the default `runloop.ai`, and visible when a custom base URL is configured

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (587/587 unit tests)
- [x] `rli agent create --help` hides `--public` with default domain
- [x] `RUNLOOP_BASE_URL=https://api.custom.dev rli agent create --help` shows `--public`
- [x] Same behavior verified for `rli object upload --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)