### PR TITLE
feat(devbox): show running and created-in-timeframe counts in list

### DIFF
--- a/src/commands/devbox/list.tsx
+++ b/src/commands/devbox/list.tsx
@@ -105,7 +105,11 @@ const ListDevboxesUI = ({
       // Fetch ONE page only
       const page = (await client.devboxes.list(
         queryParams,
-      )) as unknown as DevboxesCursorIDPage<Devbox> & { total_count?: number };
+      )) as unknown as DevboxesCursorIDPage<Devbox> & {
+        total_count?: number;
+        running_count?: number;
+        created_in_timeframe_count?: number;
+      };
 
       // Extract data and create defensive copies using JSON serialization
       if (page.devboxes && Array.isArray(page.devboxes)) {
@@ -118,6 +122,8 @@ const ListDevboxesUI = ({
         items: pageDevboxes,
         hasMore: page.has_more || false,
         totalCount: page.total_count,
+        runningCount: page.running_count,
+        createdInTimeframeCount: page.created_in_timeframe_count,
       };
 
       return result;
@@ -135,6 +141,8 @@ const ListDevboxesUI = ({
     hasMore,
     hasPrev,
     totalCount,
+    runningCount,
+    createdInTimeframeCount,
     nextPage,
     prevPage,
   } = useCursorPagination({
@@ -747,6 +755,37 @@ const ListDevboxesUI = ({
               </Text>
             </>
           )}
+          {runningCount !== undefined && runningCount > 0 && (
+            <>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                •{" "}
+              </Text>
+              <Text color={colors.success} bold>
+                {runningCount}
+              </Text>
+              <Text color={colors.textDim} dimColor>
+                {" "}
+                running
+              </Text>
+            </>
+          )}
+          {createdInTimeframeCount !== undefined &&
+            createdInTimeframeCount > 0 && (
+              <>
+                <Text color={colors.textDim} dimColor>
+                  {" "}
+                  •{" "}
+                </Text>
+                <Text color={colors.info} bold>
+                  {createdInTimeframeCount}
+                </Text>
+                <Text color={colors.textDim} dimColor>
+                  {" "}
+                  created in range
+                </Text>
+              </>
+            )}
           {totalCount > 0 && totalPages > 1 && (
             <>
               <Text color={colors.textDim} dimColor>

--- a/src/hooks/useCursorPagination.ts
+++ b/src/hooks/useCursorPagination.ts
@@ -19,6 +19,8 @@ export interface UsePaginatedListConfig<T> {
     items: T[];
     hasMore: boolean;
     totalCount?: number;
+    runningCount?: number;
+    createdInTimeframeCount?: number;
     /** Opaque cursor for the next page. If omitted, last item ID is used. */
     nextCursor?: string;
   }>;
@@ -67,6 +69,12 @@ export interface UsePaginatedListResult<T> {
   /** Total count of items (if available from API) */
   totalCount: number;
 
+  /** Count of items currently in running state (if available from API) */
+  runningCount?: number;
+
+  /** Count of items created in the queried time range (if available from API) */
+  createdInTimeframeCount?: number;
+
   /** Navigate to next page */
   nextPage: () => void;
 
@@ -111,6 +119,12 @@ export function useCursorPagination<T>(
   const [currentPage, setCurrentPage] = React.useState(0);
   const [hasMore, setHasMore] = React.useState(false);
   const [totalCount, setTotalCount] = React.useState(0);
+  const [runningCount, setRunningCount] = React.useState<number | undefined>(
+    undefined,
+  );
+  const [createdInTimeframeCount, setCreatedInTimeframeCount] = React.useState<
+    number | undefined
+  >(undefined);
   // Track if we have a cached total count from the API (to avoid re-requesting)
   const hasCachedTotalCountRef = React.useRef(false);
 
@@ -216,6 +230,14 @@ export function useCursorPagination<T>(
         // Update pagination state
         setHasMore(result.hasMore);
 
+        // Update running count and created in timeframe count if available
+        if (result.runningCount !== undefined) {
+          setRunningCount(result.runningCount);
+        }
+        if (result.createdInTimeframeCount !== undefined) {
+          setCreatedInTimeframeCount(result.createdInTimeframeCount);
+        }
+
         // If has_more is false on any page, we know the exact total count.
         // Cancel the background count request if still pending.
         if (!result.hasMore && !hasCachedTotalCountRef.current) {
@@ -252,6 +274,8 @@ export function useCursorPagination<T>(
     setCurrentPage(0);
     setItems([]);
     setHasMore(false);
+    setRunningCount(undefined);
+    setCreatedInTimeframeCount(undefined);
     // Don't reset totalCount to 0 — keep old value visible while new count loads
     // Fire both data and count requests immediately in parallel.
     // If the data request returns first with hasMore=false, cancel the count request.
@@ -282,6 +306,12 @@ export function useCursorPagination<T>(
             if (isUnfiltered) {
               baseTotalCountRef.current = result.totalCount;
             }
+          }
+          if (result.runningCount !== undefined) {
+            setRunningCount(result.runningCount);
+          }
+          if (result.createdInTimeframeCount !== undefined) {
+            setCreatedInTimeframeCount(result.createdInTimeframeCount);
           }
         })
         .catch(() => {}); // count failure is non-critical
@@ -338,6 +368,8 @@ export function useCursorPagination<T>(
     hasMore,
     hasPrev: currentPage > 0,
     totalCount,
+    runningCount,
+    createdInTimeframeCount,
     nextPage,
     prevPage,
     refresh,


### PR DESCRIPTION
### Description

Display two new counts from the devbox list API in the TUI statistics bar:
- **running count** (green): number of devboxes currently in RUNNING state
- **created in range** (blue): number of devboxes created in the queried time range (only shown when a time range is specified)

Changes:
- `list.tsx`: extend API response type cast to include `running_count` and `created_in_timeframe_count`, extract and pass them through
- `useCursorPagination.ts`: add `runningCount` and `createdInTimeframeCount` state and expose them from the hook
- Statistics bar: display the new counts between "total" and page info

### Motivation

Depends on runloopai/runloop#9295 which adds `running_count` and `created_in_timeframe_count` to the devbox list API response.

### Testing

- Build succeeds (pre-existing nanotar type issue resolved by `pnpm install`)
- Lint passes with only pre-existing warnings
- Counts only display when values are defined and > 0