### PR TITLE
chore(deps): patch 3 Dependabot alerts (tmp, qs, ws)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "ink-spinner": "5.0.0",
     "ink-text-input": "6.0.0",
     "react": "19.2.0",
-    "ws": "^8.18.0",
+    "ws": "^8.20.1",
     "tar-stream": "3.1.7",
     "yaml": "2.8.3",
     "zustand": "5.0.10"
@@ -99,8 +99,9 @@
       "esbuild"
     ],
     "overrides": {
-      "tmp": "^0.2.5",
-      "qs": "^6.15.1",
+      "tmp": "^0.2.6",
+      "qs": "^6.15.2",
+      "ws": "^8.20.1",
       "hono": "4.12.18",
       "@hono/node-server": "^1.19.14",
       "@modelcontextprotocol/sdk>ajv": "^8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  tmp: ^0.2.5
-  qs: ^6.15.1
+  tmp: ^0.2.6
+  qs: ^6.15.2
+  ws: ^8.20.1
   hono: 4.12.18
   '@hono/node-server': ^1.19.14
   '@modelcontextprotocol/sdk>ajv': ^8.18.0
@@ -95,8 +96,8 @@ importers:
         specifier: 3.1.7
         version: 3.1.7
       ws:
-        specifier: ^8.18.0
-        version: 8.19.0
+        specifier: ^8.20.1
+        version: 8.21.0
       yaml:
         specifier: 2.8.3
         version: 2.8.3
@@ -2605,8 +2606,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -2912,8 +2913,8 @@ packages:
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -3145,8 +3146,8 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4379,7 +4380,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -4959,7 +4960,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4974,7 +4975,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.5
+      tmp: 0.2.7
 
   fast-deep-equal@3.1.3: {}
 
@@ -5317,7 +5318,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
-      ws: 8.19.0
+      ws: 8.21.0
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.10
@@ -6163,7 +6164,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -6551,7 +6552,7 @@ snapshots:
       '@types/tinycolor2': 1.4.6
       tinycolor2: 1.6.0
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 
@@ -6801,7 +6802,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Patches the 3 open Dependabot alerts, all transitive npm deps, following the repo's existing `pnpm.overrides` pattern.

| # | Sev | Pkg | Was | Now | Source |
|---|-----|-----|-----|-----|--------|
| 75 | high | `tmp` | 0.2.5 | 0.2.7 | `@anthropic-ai/mcpb` → external-editor |
| 74 | medium | `qs` | 6.15.1 | 6.15.2 | `express` / body-parser |
| 73 | medium | `ws` | 8.19.0 | 8.21.0 | `ink` (+ direct dep) |

## Changes
- Bump `tmp` override floor `^0.2.5` → `^0.2.6`
- Bump `qs` override floor `^6.15.1` → `^6.15.2`
- Add `ws` override `^8.20.1` and raise the direct `ws` dep floor `^8.18.0` → `^8.20.1` so the ranges agree

## Verification
- `pnpm audit` → **No known vulnerabilities found**
- `pnpm build` (tsc) → clean
- Tests: 793/797 pass. The 4 failures are e2e tests hitting `401 Invalid Authorization` (no API key in CI env) — unrelated to these bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)