### PR TITLE
chore(deps): patch 4 Dependabot alerts (hono 4.12.24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       "tmp": "^0.2.6",
       "qs": "^6.15.2",
       "ws": "^8.20.1",
-      "hono": "4.12.18",
+      "hono": "4.12.24",
       "@hono/node-server": "^1.19.14",
       "@modelcontextprotocol/sdk>ajv": "^8.18.0",
       "express-rate-limit": "^8.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   tmp: ^0.2.6
   qs: ^6.15.2
   ws: ^8.20.1
-  hono: 4.12.18
+  hono: 4.12.24
   '@hono/node-server': ^1.19.14
   '@modelcontextprotocol/sdk>ajv': ^8.18.0
   express-rate-limit: ^8.3.2
@@ -546,7 +546,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.18
+      hono: 4.12.24
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1785,8 +1785,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.24:
+    resolution: {integrity: sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3570,9 +3570,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.24)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.24
 
   '@humanfs/core@0.19.1': {}
 
@@ -3887,7 +3887,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.24)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3897,7 +3897,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.24
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5204,7 +5204,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.18: {}
+  hono@4.12.24: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## What

Bumps the pnpm `hono` override `4.12.18` → `4.12.24` to clear four medium Dependabot alerts (#76–#79), all fixed in hono **4.12.21**:

| Alert | GHSA | Issue |
|-------|------|-------|
| #76 | `GHSA-f577-qrjj-4474` | JWT middleware accepts any `Authorization` scheme, not just Bearer |
| #77 | `GHSA-xrhx-7g5j-rcj5` | IP restriction bypasses static deny rules for non-canonical IPv6 |
| #78 | `GHSA-2gcr-mfcq-wcc3` | `app.mount()` strips prefix using undecoded path → mis-routing on percent-encoded paths |
| #79 | `GHSA-3hrh-pfw6-9m5x` | Cookie helper does not sanitize `sameSite`/`priority` → Set-Cookie injection |

## Why this approach

`hono` is purely transitive (`@modelcontextprotocol/sdk` → `@hono/node-server`) and already governed by the pnpm `overrides` block, so a single pin bump is the clean fix. Targeting `4.12.24` (latest in the same minor line) rather than the minimum `4.12.21` — all patch-level releases, a superset of the fixes, zero breaking surface.

Peer ranges accept it: `@hono/node-server` wants `^4`, the MCP SDK wants `^4.11.4`. Lockfile resolves `hono@4.12.24` at every site with no stragglers below the patched floor.

## Verification

- `pnpm run build` (tsc) → clean
- Tests: 800/804 pass. The 4 failures are the live-API `scp`/`rsync` e2e suite failing on `401` (no API key in CI/sandbox) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)